### PR TITLE
Simplify id generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ TODOs for Release:
 - Provide an interface to allow users to replace IdGenerator with their own.
 - Copy and modify any parts of the main package test suite that can give more end to end coverage.
 - Write some basic docs. (WIP)
-- IdGenerator is a bit over-engineered, simplify it e.g. there's probably no need for it be a singleton with its own
-  collision prevention, it's not going to be realistic to call the same instance twice in one microsecond.
 - See if we can solve for LazyCollection->remember().
 
 ## Features

--- a/config/event-sourcing-dynamodb.php
+++ b/config/event-sourcing-dynamodb.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 // config for BlackFrog/LaravelEventSourcingDynamodb
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimeStampIdGenerator;
 
 return [
     'dynamodb-client' => [
@@ -68,5 +69,6 @@ return [
         'BillingMode' => 'PAY_PER_REQUEST',
     ],
 
+    'id_generator' => TimeStampIdGenerator::class,
     'id_timestamp_provider' => MicroTimestampProvider::class,
 ];

--- a/config/event-sourcing-dynamodb.php
+++ b/config/event-sourcing-dynamodb.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // config for BlackFrog/LaravelEventSourcingDynamodb
-use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimeTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
 
 return [
     'dynamodb-client' => [
@@ -68,5 +68,5 @@ return [
         'BillingMode' => 'PAY_PER_REQUEST',
     ],
 
-    'id_timestamp_provider' => MicroTimeTimestampProvider::class,
+    'id_timestamp_provider' => MicroTimestampProvider::class,
 ];

--- a/src/IdGeneration/IdGenerator.php
+++ b/src/IdGeneration/IdGenerator.php
@@ -1,69 +1,8 @@
 <?php
 
-declare(strict_types=1);
-
 namespace BlackFrog\LaravelEventSourcingDynamodb\IdGeneration;
 
-use Random\Randomizer;
-use RuntimeException;
-
-class IdGenerator
+interface IdGenerator
 {
-    /**
-     * We ensure that we don't generate a number with more digits than can
-     * fit in an integer (PHP_INT_MAX) on 64bit PHP.
-     *
-     * @see PHP_INT_MAX
-     */
-    const TARGET_ID_LENGTH = 19;
-
-    public function __construct(
-        private readonly Randomizer $randomizer,
-        private readonly TimestampProvider $timestampProvider,
-    ) {
-    }
-
-    public function generateId(): int
-    {
-        $timestamp = $this->timestamp();
-
-        //We want enough random digits to create an integer id that fits inside INT_MAX on 64bit PHP.
-        $randomIntDigits = static::TARGET_ID_LENGTH - strlen((string) $timestamp);
-        $randomInt = $this->randomIntAsZeroFilledString($randomIntDigits);
-
-        $id = (int) ($timestamp.$randomInt);
-
-        $this->exceptIfIntIsNegative($id);
-        $this->exceptIfIntMaxIsReached($id);
-
-        return $id;
-    }
-
-    private function timestamp(): int
-    {
-        return $this->timestampProvider->microsecondsTimestamp();
-    }
-
-    private function randomIntAsZeroFilledString(int $digits): string
-    {
-        $max = pow(10, $digits) - 1;
-
-        $int = $this->randomizer->getInt(0, $max);
-
-        return sprintf("%0{$digits}d", $int);
-    }
-
-    private function exceptIfIntMaxIsReached(int $id): void
-    {
-        if ($id === PHP_INT_MAX) {
-            throw new RuntimeException('PHP_INT_MAX limit reached.');
-        }
-    }
-
-    private function exceptIfIntIsNegative(int $id): void
-    {
-        if ($id < 0) {
-            throw new RuntimeException('Negative Id generated.');
-        }
-    }
+    public function generateId(): int;
 }

--- a/src/IdGeneration/IdGenerator.php
+++ b/src/IdGeneration/IdGenerator.php
@@ -17,71 +17,19 @@ class IdGenerator
      */
     const TARGET_ID_LENGTH = 19;
 
-    /**
-     * We track the last timestamp used to generate an id, so we can
-     * avoid an instance of this class returning the same $id value twice.
-     */
-    private ?int $timestamp = null;
-
-    /**
-     * We track the random integers used for the current microsecond timestamp, so we can
-     * avoid one instance of this class returning the same $id value twice.
-     */
-    private array $randomIntsUsed = [];
-
-    /**
-     * Total possible unique values in a given microsecond but as we approach this limit
-     * the likelihood of generating a unique one decreases and therefore
-     * the cost grows exponentially. We set this number lower to avoid this problem.
-     */
-    private int $maxUniqueInts;
-
-    /**
-     * @var int
-     * We use the initTimestamp to offer us some basic protection
-     * against the system clock changing backwards during the
-     * life of this instance. It is set on first id generation.
-     */
-    private int $initTimestamp;
-
     public function __construct(
         private readonly Randomizer $randomizer,
         private readonly TimestampProvider $timestampProvider,
-        private readonly int $clockSkewWaitMicroseconds = 2_000_000 //2 seconds
     ) {
     }
 
     public function generateId(): int
     {
-        $timestamp = $this->microsecondsTimestamp();
-        $this->initTimestamp ??= $timestamp;
-
-        //If the clock has been changed backwards since the last id was generated, wait for it to catch up
-        if ($timestamp < $this->timestamp) {
-            return $this->handleClockSkew($timestamp);
-        }
+        $timestamp = $this->timestamp();
 
         //We want enough random digits to create an integer id that fits inside INT_MAX on 64bit PHP.
         $randomIntDigits = static::TARGET_ID_LENGTH - strlen((string) $timestamp);
         $randomInt = $this->randomIntAsZeroFilledString($randomIntDigits);
-
-        //If we've generated an id for this timestamp already, we need to check for collisions.
-        if ($timestamp === $this->timestamp) {
-            $this->exceptIfNoUniqueValuesRemain($randomIntDigits);
-            //If we've generated this int before for the current timestamp, we try again until we get a unique value.
-            while (in_array($randomInt, $this->randomIntsUsed)) {
-                //If we've exhausted the number of values we want to generate per timestamp, throw an exception.
-                $this->exceptIfNoUniqueValuesRemain($randomIntDigits);
-                $randomInt = $this->randomIntAsZeroFilledString($randomIntDigits);
-            }
-        } else {
-            //The timestamp has changed since the last call, so we can reset state.
-            $this->randomIntsUsed = [];
-            unset($this->maxUniqueInts);
-        }
-
-        $this->timestamp = $timestamp;
-        $this->randomIntsUsed[] = $randomInt;
 
         $id = (int) ($timestamp.$randomInt);
 
@@ -91,22 +39,7 @@ class IdGenerator
         return $id;
     }
 
-    private function handleClockSkew(int $timestamp): int
-    {
-        $skewMicroseconds = $this->timestamp - $timestamp;
-
-        if ($skewMicroseconds > $this->clockSkewWaitMicroseconds) {
-            throw new \RuntimeException(
-                "Backwards system clock change greater than {$this->clockSkewWaitMicroseconds} microseconds detected."
-            );
-        }
-
-        usleep($skewMicroseconds);
-
-        return $this->generateId();
-    }
-
-    private function microsecondsTimestamp(): int
+    private function timestamp(): int
     {
         return $this->timestampProvider->microsecondsTimestamp();
     }
@@ -120,22 +53,8 @@ class IdGenerator
         return sprintf("%0{$digits}d", $int);
     }
 
-    private function exceptIfNoUniqueValuesRemain(int $randomIntDigits): void
-    {
-        if (isset($this->maxUniqueInts) === false) {
-            $maxValue = pow(10, $randomIntDigits) - 1;
-            //We cap this to 80% of the total available space as performance degrades rapidly as we approach
-            //the true mathematical limit on possible unique values as we have to regenerate too many times.
-            $this->maxUniqueInts = (int) ((80 / 100) * $maxValue);
-        }
-        if (count($this->randomIntsUsed) > $this->maxUniqueInts) {
-            throw new RuntimeException('Unable to generate a unique value.');
-        }
-    }
-
     private function exceptIfIntMaxIsReached(int $id): void
     {
-        //If PHP_INT_MAX is reached we have possible integer overflow and cannot trust the id generated.
         if ($id === PHP_INT_MAX) {
             throw new RuntimeException('PHP_INT_MAX limit reached.');
         }

--- a/src/IdGeneration/MicroTimestampProvider.php
+++ b/src/IdGeneration/MicroTimestampProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BlackFrog\LaravelEventSourcingDynamodb\IdGeneration;
 
-class MicroTimeTimestampProvider implements TimestampProvider
+class MicroTimestampProvider implements TimestampProvider
 {
     public function microsecondsTimestamp(): int
     {

--- a/src/IdGeneration/TimeStampIdGenerator.php
+++ b/src/IdGeneration/TimeStampIdGenerator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BlackFrog\LaravelEventSourcingDynamodb\IdGeneration;
+
+use Random\Randomizer;
+use RuntimeException;
+
+class TimeStampIdGenerator implements IdGenerator
+{
+    /**
+     * We ensure that we don't generate a number with more digits than can
+     * fit in an integer (PHP_INT_MAX) on 64bit PHP.
+     *
+     * @see PHP_INT_MAX
+     */
+    const TARGET_ID_LENGTH = 19;
+
+    public function __construct(
+        private readonly Randomizer $randomizer,
+        private readonly TimestampProvider $timestampProvider,
+    ) {
+    }
+
+    public function generateId(): int
+    {
+        $timestamp = $this->timestamp();
+
+        //We want enough random digits to create an integer id that fits inside INT_MAX on 64bit PHP.
+        $randomIntDigits = static::TARGET_ID_LENGTH - strlen((string) $timestamp);
+        $randomInt = $this->randomIntAsZeroFilledString($randomIntDigits);
+
+        $id = (int) ($timestamp.$randomInt);
+
+        $this->exceptIfIntIsNegative($id);
+        $this->exceptIfIntMaxIsReached($id);
+
+        return $id;
+    }
+
+    private function timestamp(): int
+    {
+        return $this->timestampProvider->microsecondsTimestamp();
+    }
+
+    private function randomIntAsZeroFilledString(int $digits): string
+    {
+        $max = pow(10, $digits) - 1;
+
+        $int = $this->randomizer->getInt(0, $max);
+
+        return sprintf("%0{$digits}d", $int);
+    }
+
+    private function exceptIfIntMaxIsReached(int $id): void
+    {
+        if ($id === PHP_INT_MAX) {
+            throw new RuntimeException('PHP_INT_MAX limit reached.');
+        }
+    }
+
+    private function exceptIfIntIsNegative(int $id): void
+    {
+        if ($id < 0) {
+            throw new RuntimeException('Negative Id generated.');
+        }
+    }
+}

--- a/src/LaravelEventSourcingDynamodbServiceProvider.php
+++ b/src/LaravelEventSourcingDynamodbServiceProvider.php
@@ -8,6 +8,7 @@ use Aws\DynamoDb\DynamoDbClient;
 use BlackFrog\LaravelEventSourcingDynamodb\Commands\CreateTables;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\IdGenerator;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimeStampIdGenerator;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimestampProvider;
 use BlackFrog\LaravelEventSourcingDynamodb\Snapshots\DynamoDbSnapshotRepository;
 use BlackFrog\LaravelEventSourcingDynamodb\StoredEvents\DynamoDbStoredEventRepository;
@@ -21,9 +22,15 @@ class LaravelEventSourcingDynamodbServiceProvider extends PackageServiceProvider
     {
         parent::register();
 
-        $this->app->singleton(IdGenerator::class);
+        $this->app->singleton(
+            IdGenerator::class,
+            config(
+                'event-sourcing-dynamodb.id_generator',
+                TimeStampIdGenerator::class
+            )
+        );
 
-        $this->app->bind(
+        $this->app->singleton(
             TimestampProvider::class,
             config(
                 'event-sourcing-dynamodb.id_timestamp_provider',

--- a/src/LaravelEventSourcingDynamodbServiceProvider.php
+++ b/src/LaravelEventSourcingDynamodbServiceProvider.php
@@ -7,7 +7,7 @@ namespace BlackFrog\LaravelEventSourcingDynamodb;
 use Aws\DynamoDb\DynamoDbClient;
 use BlackFrog\LaravelEventSourcingDynamodb\Commands\CreateTables;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\IdGenerator;
-use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimeTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimestampProvider;
 use BlackFrog\LaravelEventSourcingDynamodb\Snapshots\DynamoDbSnapshotRepository;
 use BlackFrog\LaravelEventSourcingDynamodb\StoredEvents\DynamoDbStoredEventRepository;
@@ -27,7 +27,7 @@ class LaravelEventSourcingDynamodbServiceProvider extends PackageServiceProvider
             TimestampProvider::class,
             config(
                 'event-sourcing-dynamodb.id_timestamp_provider',
-                MicroTimeTimestampProvider::class
+                MicroTimestampProvider::class
             )
         );
 

--- a/tests/IdGeneration/IdGeneratorTest.php
+++ b/tests/IdGeneration/IdGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\IdGenerator;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimeStampIdGenerator;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimestampProvider;
 use Random\Randomizer;
 
@@ -20,7 +20,7 @@ beforeAll(function () {
 });
 
 beforeEach(function () {
-    $this->idGenerator = new IdGenerator(new Randomizer(), new MicroTimestampProvider());
+    $this->idGenerator = new TimeStampIdGenerator(new Randomizer(), new MicroTimestampProvider());
 });
 
 afterEach(function () {
@@ -98,7 +98,7 @@ it('produces no duplicate ids over 50,000 iterations', function () {
 
 it('uses the provided integer timestamp as the start of each id', function () {
     $microTimeStamp = 1679836125000000;
-    $this->idGenerator = new IdGenerator(new Randomizer(), new FixedTimestampProvider($microTimeStamp));
+    $this->idGenerator = new TimeStampIdGenerator(new Randomizer(), new FixedTimestampProvider($microTimeStamp));
 
     $id = $this->idGenerator->generateId();
     $idAsString = (string) $id;
@@ -115,9 +115,9 @@ it('may generate duplicate ids if two instances are used at the same microsecond
 
     //450 iterations in one microsecond guarantees at least some collisions between two instances.
     $iterations = 450;
-    $idGenerator1 = new IdGenerator(new Randomizer(), $timestampProvider);
+    $idGenerator1 = new TimeStampIdGenerator(new Randomizer(), $timestampProvider);
     $idsGenerated1 = [];
-    $idGenerator2 = new IdGenerator(new Randomizer(), $timestampProvider);
+    $idGenerator2 = new TimeStampIdGenerator(new Randomizer(), $timestampProvider);
     $idsGenerated2 = [];
 
     $x = 1;
@@ -135,7 +135,7 @@ it('generates ids even when the system date is a unix date early in the epoch', 
     //Fix the current time to 1 microsecond since the start of unix epoch.
     $microTimeStamp = 1;
     $timestampProvider = new FixedTimestampProvider($microTimeStamp);
-    $this->idGenerator = new IdGenerator(new Randomizer(), $timestampProvider);
+    $this->idGenerator = new TimeStampIdGenerator(new Randomizer(), $timestampProvider);
 
     $id = $this->idGenerator->generateId();
 
@@ -150,7 +150,7 @@ it('generates ids with reduced entropy when system date is 2286-11-20 onwards', 
     //The id generator soldiers on with reduced entropy by generating one less random digit to append.
     $microTimeStamp = 10000000000000000;
     $timestampProvider = new FixedTimestampProvider($microTimeStamp);
-    $this->idGenerator = new IdGenerator(new Randomizer(), $timestampProvider);
+    $this->idGenerator = new TimeStampIdGenerator(new Randomizer(), $timestampProvider);
 
     //The max iterations per microsecond falls to 79 due to fewer available random numbers.
     $iterations = 79;

--- a/tests/Snapshots/DynamoDbSnapshotRepositoryTest.php
+++ b/tests/Snapshots/DynamoDbSnapshotRepositoryTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Aws\DynamoDb\Marshaler;
-use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\IdGenerator;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\TimeStampIdGenerator;
 use BlackFrog\LaravelEventSourcingDynamodb\Snapshots\DynamoDbSnapshotRepository;
 use BlackFrog\LaravelEventSourcingDynamodb\Snapshots\StateSerializer;
 use Random\Randomizer;
@@ -26,7 +26,7 @@ beforeEach(function () {
 
     $this->snapshotRepository = new DynamoDbSnapshotRepository(
         $this->getDynamoDbClient(),
-        new IdGenerator(new Randomizer(), new MicroTimestampProvider()),
+        new TimeStampIdGenerator(new Randomizer(), new MicroTimestampProvider()),
         new Marshaler(),
         new StateSerializer()
     );

--- a/tests/Snapshots/DynamoDbSnapshotRepositoryTest.php
+++ b/tests/Snapshots/DynamoDbSnapshotRepositoryTest.php
@@ -2,7 +2,7 @@
 
 use Aws\DynamoDb\Marshaler;
 use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\IdGenerator;
-use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimeTimestampProvider;
+use BlackFrog\LaravelEventSourcingDynamodb\IdGeneration\MicroTimestampProvider;
 use BlackFrog\LaravelEventSourcingDynamodb\Snapshots\DynamoDbSnapshotRepository;
 use BlackFrog\LaravelEventSourcingDynamodb\Snapshots\StateSerializer;
 use Random\Randomizer;
@@ -26,7 +26,7 @@ beforeEach(function () {
 
     $this->snapshotRepository = new DynamoDbSnapshotRepository(
         $this->getDynamoDbClient(),
-        new IdGenerator(new Randomizer(), new MicroTimeTimestampProvider()),
+        new IdGenerator(new Randomizer(), new MicroTimestampProvider()),
         new Marshaler(),
         new StateSerializer()
     );

--- a/tests/StoredEvents/DynamoDbStoredEventRepositoryTest.php
+++ b/tests/StoredEvents/DynamoDbStoredEventRepositoryTest.php
@@ -53,7 +53,7 @@ it('can persist and retrieve an event with a null uuid', function () {
         ->and($retrievedEvent->aggregate_uuid)->toEqual('null');
 });
 
-it('can store many events', function () {
+it('can persist many events', function () {
     $aggregateUuid = Uuid::uuid4();
     $eventOne = new DummyStorableEvent('blahh');
     $eventTwo = new DummyStorableEvent('yahhh');


### PR DESCRIPTION
Remove protections for clock skew and returning the same id twice from one instance (functionally impossible due to microsecond timestamp) as they overcomplicate the process and make it scary to anyone reviewing.

Add an interface that allows users to provide their own id generator if they are unhappy with the provided implementation or need a more advanced mechanism (locking, collision prevention or externally sourced ids.)