### PR TITLE
Removes the filter expression in `DynamoDbStoredEventRepository::retrieveAllAfterVersion()`. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ that might break compatibility with read consistency.
   attributes) that has the `id` as both the `HASH` and `RANGE` keys supports fetching events without their aggregate
   uuid while preserving their order, both `find($id)` and `retrieveAll(null)` use this.
 - A [Local Secondary Index](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html) (projects keys
-  only) has `aggregate_uuid` as `HASH` and `aggregate_version` as `RANGE` to support `getLatestAggregateVersion()`. This
-  can be changed to a GSI if you don't need the read consistency feature. See [DynamoDB Limitations](#dynamodb) for more
+  only) has `version_id` (composite of version and id) as `RANGE` to support `getLatestAggregateVersion()`. This
+  can be changed to a GSI if you definitely don't need the read consistency feature. See [DynamoDB Limitations](#dynamodb) for more
   info.
 - Event order is preserved using a generated incrementing integer id based on the current microsecond timestamp.
   This is necessary for compatibility with the Spatie package, see [Event Ids](#event-ids) for details.
@@ -97,7 +97,7 @@ that might break compatibility with read consistency.
   configure [consistent reads from DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html)
   using the `read_consistency` config key (defaults to `false`.) This only applies to methods where you pass an
   aggregate root UUID as an argument. Some method calls on the EventRepository such as `find($id)`
-  and `retrieveAll(null)` remain eventually consistent.
+  and `retrieveAll(null)` will remain eventually consistent.
 
 ### Lazy Collections
 
@@ -110,10 +110,10 @@ that might break compatibility with read consistency.
 ### DynamoDB
 
 - Individual Events cannot exceed 400KB in size, which is max size of a DynamoDB item.
-- The maximum size of all events data per Aggregate UUID is 10GB due to the use of
-  a [Local Secondary Index](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html), If you do not
+- The maximum total size of all events data per Aggregate UUID is 10GB due to the use of
+  a [Local Secondary Index](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html). If you do not
   intend to use the [read consistency](#read-consistency) feature, you can remove this limitation by moving the
-  index `aggregate_uuid-version-index` to the `GlobalSecondaryIndexes` **before** creating tables.
+  index `aggregate_uuid-version-id-index` to the `GlobalSecondaryIndexes` **before** creating tables.
 - The package expects `PAY_PER_REQUEST` billing mode behaviour and doesn't currently support provisioned throughput.
   For example, there's no handling of throughput exceeded exceptions nor a wait/retry mechanism for this.
 
@@ -215,6 +215,7 @@ before launching your project.
   specified per event.
 - More granular control over read consistency mode, e.g. configurable per method, or able to change a repo binding
   on the fly to get one that is read consistent.
+- Support for provisioned capacity billing, specifically handling exceptions and retries.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ serverless approach to your event and snapshot data storage.
 
 - The package implements a paginator that lets you iterate through large result sets as LazyCollections, backed by the
   AWS PHP paginator. However, bear in mind this can result in repeated DynamoDB requests, if you would rather avoid this
-  and keep the results in memory after you've access them, just call `->remember()` on the collection.
+  and keep the results in memory after you access them, just call `->remember()` on the collection.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ serverless approach to your event and snapshot data storage.
 
 - Review approach to handling event metadata, ensure its compatible.
 - Copy and modify any parts of the main package test suite that can give more end to end coverage.
+- Find a way to run the test suite twice, one with read consistency mode on to give us coverage for changes
+that might break compatibility with read consistency.
 
 ## Should I use DynamoDB?
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ serverless approach to your event and snapshot data storage.
 
 **TODOs for first release:**
 
-- `DynamoDbStoredEventRepository::RetrieveAllAfterVersion()` uses a filter expression which isn't cost efficient.
 - Review approach to handling event metadata, ensure its compatible.
 - Copy and modify any parts of the main package test suite that can give more end to end coverage.
 

--- a/config/event-sourcing-dynamodb.php
+++ b/config/event-sourcing-dynamodb.php
@@ -27,7 +27,6 @@ return [
             ['AttributeName' => 'sort_id', 'AttributeType' => 'N'],
             ['AttributeName' => 'aggregate_uuid', 'AttributeType' => 'S'],
             ['AttributeName' => 'aggregate_version', 'AttributeType' => 'N'],
-            ['AttributeName' => 'version_uuid', 'AttributeType' => 'S'], //Get rid?
             ['AttributeName' => 'version_id', 'AttributeType' => 'S'],
         ],
         'KeySchema' => [
@@ -52,14 +51,6 @@ return [
                     ['AttributeName' => 'sort_id', 'KeyType' => 'RANGE'],
                 ],
                 'Projection' => ['ProjectionType' => 'ALL'],
-            ],
-            [
-                'IndexName' => 'version_uuid-id-index',
-                'KeySchema' => [
-                    ['AttributeName' => 'version_uuid', 'KeyType' => 'HASH'],
-                    ['AttributeName' => 'id', 'KeyType' => 'RANGE'],
-                ],
-                'Projection' => ['ProjectionType' => 'KEYS_ONLY'],
             ],
         ],
         'BillingMode' => 'PAY_PER_REQUEST',

--- a/config/event-sourcing-dynamodb.php
+++ b/config/event-sourcing-dynamodb.php
@@ -27,6 +27,7 @@ return [
             ['AttributeName' => 'sort_id', 'AttributeType' => 'N'],
             ['AttributeName' => 'aggregate_uuid', 'AttributeType' => 'S'],
             ['AttributeName' => 'aggregate_version', 'AttributeType' => 'N'],
+            ['AttributeName' => 'version_uuid', 'AttributeType' => 'S'],
         ],
         'KeySchema' => [
             ['AttributeName' => 'aggregate_uuid', 'KeyType' => 'HASH'],
@@ -50,6 +51,14 @@ return [
                     ['AttributeName' => 'sort_id', 'KeyType' => 'RANGE'],
                 ],
                 'Projection' => ['ProjectionType' => 'ALL'],
+            ],
+            [
+                'IndexName' => 'version_uuid-id-index',
+                'KeySchema' => [
+                    ['AttributeName' => 'version_uuid', 'KeyType' => 'HASH'],
+                    ['AttributeName' => 'id', 'KeyType' => 'RANGE'],
+                ],
+                'Projection' => ['ProjectionType' => 'KEYS_ONLY'],
             ],
         ],
         'BillingMode' => 'PAY_PER_REQUEST',

--- a/config/event-sourcing-dynamodb.php
+++ b/config/event-sourcing-dynamodb.php
@@ -27,7 +27,8 @@ return [
             ['AttributeName' => 'sort_id', 'AttributeType' => 'N'],
             ['AttributeName' => 'aggregate_uuid', 'AttributeType' => 'S'],
             ['AttributeName' => 'aggregate_version', 'AttributeType' => 'N'],
-            ['AttributeName' => 'version_uuid', 'AttributeType' => 'S'],
+            ['AttributeName' => 'version_uuid', 'AttributeType' => 'S'], //Get rid?
+            ['AttributeName' => 'version_id', 'AttributeType' => 'S'],
         ],
         'KeySchema' => [
             ['AttributeName' => 'aggregate_uuid', 'KeyType' => 'HASH'],
@@ -35,10 +36,10 @@ return [
         ],
         'LocalSecondaryIndexes' => [
             [
-                'IndexName' => 'aggregate_uuid-version-index',
+                'IndexName' => 'aggregate_uuid-version-id-index',
                 'KeySchema' => [
                     ['AttributeName' => 'aggregate_uuid', 'KeyType' => 'HASH'],
-                    ['AttributeName' => 'aggregate_version', 'KeyType' => 'RANGE'],
+                    ['AttributeName' => 'version_id', 'KeyType' => 'RANGE'],
                 ],
                 'Projection' => ['ProjectionType' => 'KEYS_ONLY'],
             ],

--- a/src/StoredEvents/DynamoDbStoredEventRepository.php
+++ b/src/StoredEvents/DynamoDbStoredEventRepository.php
@@ -129,8 +129,6 @@ readonly class DynamoDbStoredEventRepository implements StoredEventRepository
 
     public function retrieveAllAfterVersion(int $aggregateVersion, string $aggregateUuid): LazyCollection
     {
-        //For this version and this aggregate uuid get the most recent event id.
-
         $lastEventIdForAggregateVersion = $this->lastEventIdForAggregateVersion($aggregateUuid, $aggregateVersion);
 
         $resultPaginator = $this->dynamo->getPaginator('Query', [

--- a/src/StoredEvents/DynamoDbStoredEventRepository.php
+++ b/src/StoredEvents/DynamoDbStoredEventRepository.php
@@ -224,7 +224,6 @@ readonly class DynamoDbStoredEventRepository implements StoredEventRepository
 
         //Extra attributes to work around dynamo indexing limitations, allowing consistent event ordering.
         $storedEventArray['sort_id'] = $storedEventArray['id'];
-        $storedEventArray['version_uuid'] = $storedEventArray['aggregate_version'].'_'.$storedEventArray['aggregate_uuid']; //Get rid?
         $storedEventArray['version_id'] = $storedEventArray['aggregate_version'].'_'.$storedEventArray['id'];
 
         //Format carbon object for storage. Temporary bodge, this needs more work.

--- a/tests/StoredEvents/DynamoDbStoredEventRepositoryTest.php
+++ b/tests/StoredEvents/DynamoDbStoredEventRepositoryTest.php
@@ -274,15 +274,16 @@ it('retrieves all events for an aggregate root uuid starting from an event id', 
 it('gets the latest aggregate version for an aggregate root uuid', function () {
     $aggregateRootUuid = Uuid::uuid4();
     $event = new DummyStorableEvent('yahhh');
+
     $event->setAggregateRootVersion(1);
     $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
-    $event->setAggregateRootVersion(5);
+    $event->setAggregateRootVersion(3);
     $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
-    $event->setAggregateRootVersion(3);
+    $event->setAggregateRootVersion(5);
     $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
@@ -300,8 +301,16 @@ it('retrieves events after a version for an aggregate root uuid', function () {
     $aggregateRootUuid = Uuid::uuid4();
     $event = new DummyStorableEvent('yahhh');
 
-    $event->setAggregateRootVersion(5);
-    $event1 = $this->storedEventRepository
+    $event->setAggregateRootVersion(1);
+    $this->storedEventRepository
+        ->persist($event, $aggregateRootUuid);
+
+    $event->setAggregateRootVersion(3);
+    $this->storedEventRepository
+        ->persist($event, $aggregateRootUuid);
+
+    $event->setAggregateRootVersion(3);
+    $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
     $event->setAggregateRootVersion(3);
@@ -309,22 +318,22 @@ it('retrieves events after a version for an aggregate root uuid', function () {
         ->persist($event, $aggregateRootUuid);
 
     $event->setAggregateRootVersion(4);
-    $this->storedEventRepository
+    $firstEvent = $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
     $event->setAggregateRootVersion(4);
-    $event4 = $this->storedEventRepository
+    $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
-    $event->setAggregateRootVersion(1);
-    $this->storedEventRepository
+    $event->setAggregateRootVersion(5);
+    $lastEvent = $this->storedEventRepository
         ->persist($event, $aggregateRootUuid);
 
     $events = $this->storedEventRepository->retrieveAllAfterVersion(3, $aggregateRootUuid);
 
     expect($events->count())->toEqual(3)
-        ->and($events->first()->id)->toEqual($event1->id)
-        ->and($events->last()->id)->toEqual($event4->id);
+        ->and($events->first()->id)->toEqual($firstEvent->id)
+        ->and($events->last()->id)->toEqual($lastEvent->id);
 });
 
 it('returns an empty collection when no events after a version for an aggregate root uuid', function () {

--- a/tests/StoredEvents/DynamoDbStoredEventRepositoryTest.php
+++ b/tests/StoredEvents/DynamoDbStoredEventRepositoryTest.php
@@ -10,7 +10,7 @@ beforeAll(function () {
     class DummyStorableEvent extends ShouldBeStored
     {
         public function __construct(
-          public readonly string $message
+            public readonly string $message
         ) {
         }
     }


### PR DESCRIPTION
Removes the need for a filter expression in `DynamoDbStoredEventRepository::retrieveAllAfterVersion()`. 

 This also assumes that the aggregate version increments reliably alongside event ids. Put another way, it assumes that all events after the last one for the previous version have a higher incrementing id. This should be true?