### PR TITLE
Run tests again in read consistency mode.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,8 +55,12 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/pest --coverage --coverage-clover storage/coverage/coverage.xml
-
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./storage/coverage/coverage.xml
+
+      - name: Execute tests (Read consistency)
+        run: vendor/bin/pest
+        env:
+          DYNAMO_EVENTS_READ_CONSISTENCY: true

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ serverless approach to your event and snapshot data storage.
 
 - Review approach to handling event metadata, ensure its compatible.
 - Copy and modify any parts of the main package test suite that can give more end to end coverage.
-- Find a way to run the test suite twice, one with read consistency mode on to give us coverage for changes
-that might break compatibility with read consistency.
 
 ## Should I use DynamoDB?
 

--- a/config/event-sourcing-dynamodb.php
+++ b/config/event-sourcing-dynamodb.php
@@ -17,7 +17,7 @@ return [
         ],
     ],
 
-    'read_consistency' => false,
+    'read_consistency' => (bool) env('DYNAMO_EVENTS_READ_CONSISTENCY', false),
 
     'stored-event-table' => 'stored_events',
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,35 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    cacheDirectory=".phpunit.cache"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php"
+         colors="true" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true"
+         beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="BlackFrog Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
     <php>
-        <env name="AWS_ACCESS_KEY_ID" value="fakeMyKeyId" force="true" />
-        <env name="AWS_SECRET_ACCESS_KEY" value="fakeSecretAccessKey" force="true" />
-        <env name="DYNAMODB_ENDPOINT" value="http://localhost:8000" force="true" />
-        <ini name="memory_limit" value="512M" />
+        <env name="AWS_ACCESS_KEY_ID" value="fakeMyKeyId" force="true"/>
+        <env name="AWS_SECRET_ACCESS_KEY" value="fakeSecretAccessKey" force="true"/>
+        <env name="DYNAMODB_ENDPOINT" value="http://localhost:8000" force="true"/>
+        <ini name="memory_limit" value="512M"/>
     </php>
     <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
         <report>
             <html outputDirectory="build/coverage"/>
             <text outputFile="build/coverage.txt"/>
             <clover outputFile="build/logs/clover.xml"/>
         </report>
     </coverage>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/StoredEvents/DynamoStoredEventRepositoryTest.php
+++ b/tests/StoredEvents/DynamoStoredEventRepositoryTest.php
@@ -17,6 +17,9 @@ beforeAll(function () {
 });
 
 beforeEach(function () {
+    if (config('event-sourcing-dynamodb.read_consistency')) {
+        dump('read consistency mode.');
+    }
     $this->createTables();
 
     $this->storedEventRepository = app(DynamoStoredEventRepository::class);

--- a/tests/StoredEvents/DynamoStoredEventRepositoryTest.php
+++ b/tests/StoredEvents/DynamoStoredEventRepositoryTest.php
@@ -17,9 +17,6 @@ beforeAll(function () {
 });
 
 beforeEach(function () {
-    if (config('event-sourcing-dynamodb.read_consistency')) {
-        dump('read consistency mode.');
-    }
     $this->createTables();
 
     $this->storedEventRepository = app(DynamoStoredEventRepository::class);


### PR DESCRIPTION
Run the tests again in read consistency mode. This gives us at least coverage against performing queries that are incompatible with read consistency mode with the flag set, for example using a GSI. It's not possible to very the read consistency itself with dynamodb local. 